### PR TITLE
Fix Vorbis corruption

### DIFF
--- a/compileVorbis.sh
+++ b/compileVorbis.sh
@@ -8,11 +8,11 @@ if [ ! -f configure ]; then
   
   # -O20 and -04 cause problems
   # see https://github.com/kripken/emscripten/issues/264
-  sed -i '' 's/-O20/-O2/g' configure
-  sed -i '' 's/-O4/-O2/g' configure
+  perl -pi -e s,-O20,-O2,g configure
+  perl -pi -e s,-O4,-O2,g configure
   
   # finally, run configuration script
-  emconfigure ./configure --prefix="`pwd`" --disable-static
+  emconfigure ./configure --prefix="`pwd`/build" --disable-static
 fi
 
 # compile libogg
@@ -27,20 +27,20 @@ cd libvorbis
 if [ ! -f configure ]; then
   # generate configuration script
   # disable running configure automatically
-  sed -i '' 's/$srcdir\/configure/#/' autogen.sh
+  perl -pi -e 's,\$srcdir\,configure,#,' autogen.sh
   ./autogen.sh
   
   # -O20 and -04 cause problems
   # see https://github.com/kripken/emscripten/issues/264
-  sed -i '' 's/-O20/-O2/g' configure
-  sed -i '' 's/-O4/-O2/g' configure
+  perl -pi -e s,-O20,-O2,g configure
+  perl -pi -e s,-O4,-O2,g configure
   
   # disable oggpack_writealign test
-  sed -i '' 's/$ac_cv_func_oggpack_writealign/yes/' configure
+  perl -pi -e 's,\$ac_cv_func_oggpack_writealign,yes,' configure
   
   # finally, run configuration script
   mkdir -p build
-  emconfigure ./configure --prefix="$dir/libvorbis/build" --disable-oggtest --disable-static --with-ogg=$dir/libogg --with-ogg-libraries=$dir/libogg/lib
+  emconfigure ./configure --prefix="$dir/libvorbis/build" --disable-oggtest --disable-static --with-ogg=$dir/libogg --with-ogg-libraries=$dir/libogg/build/lib
 fi
 
 # compile libvorbis
@@ -50,5 +50,5 @@ emmake make install
 # compile wrapper
 cd ..
 mkdir -p build
-emcc -O3 -s RESERVED_FUNCTION_POINTERS=50 -s EXPORTED_FUNCTIONS="['_VorbisInit', '_VorbisHeaderDecode', '_VorbisGetChannels', '_VorbisGetSampleRate', '_VorbisGetNumComments', '_VorbisGetComment', '_VorbisDecode', '_VorbisDestroy']" -I libogg/include -Llibogg/lib -logg -I libvorbis/include -Llibvorbis/build/lib -lvorbis src/vorbis.c -o build/libvorbis.js
+emcc -O3 --memory-init-file 0 -s RESERVED_FUNCTION_POINTERS=50 -s EXPORTED_FUNCTIONS="['_VorbisInit', '_VorbisHeaderDecode', '_VorbisGetChannels', '_VorbisGetSampleRate', '_VorbisGetNumComments', '_VorbisGetComment', '_VorbisDecode', '_VorbisDestroy']" -I libogg/include -Llibogg/build/lib -logg -I libvorbis/include -Llibvorbis/build/lib -lvorbis src/vorbis.c -o build/libvorbis.js
 echo "module.exports = Module" >> build/libvorbis.js

--- a/src/decoder.js
+++ b/src/decoder.js
@@ -39,7 +39,7 @@ var VorbisDecoder = AV.Decoder.extend(function() {
     
     Vorbis.HEAPU8.set(packet.data, this.buf);
     var status = 0;
-    if ((status = Vorbis._VorbisDecode(this.vorbis, this.buf, packet.length, this.callback)) !== 0)
+    if ((status = Vorbis._VorbisDecode(this.vorbis, this.buf, packet.length, this.callback, packet._streamEnd, packet._granulePos)) !== 0)
       throw new Error("Vorbis decoding error: " + status);
   };
   

--- a/src/decoder.js
+++ b/src/decoder.js
@@ -12,7 +12,6 @@ var VorbisDecoder = AV.Decoder.extend(function() {
     
     this.outlen = 4096;
     this.outbuf = Vorbis._malloc(this.outlen << 2);
-    this.decodedBuffer = null;
     
     this.vorbis = Vorbis._VorbisInit(this.outbuf, this.outlen);
     
@@ -21,7 +20,7 @@ var VorbisDecoder = AV.Decoder.extend(function() {
     
     this.callback = Vorbis.Runtime.addFunction(function(len) {
       var samples = Vorbis.HEAPF32.subarray(offset, offset + len);
-      self.decodedBuffer = new Float32Array(samples);
+      self.emit('data', new Float32Array(samples));
     });
   };
   
@@ -42,8 +41,6 @@ var VorbisDecoder = AV.Decoder.extend(function() {
     var status = 0;
     if ((status = Vorbis._VorbisDecode(this.vorbis, this.buf, packet.length, this.callback)) !== 0)
       throw new Error("Vorbis decoding error: " + status);
-      
-    return this.decodedBuffer;
   };
   
   this.prototype.destroy = function() {

--- a/src/demuxer.js
+++ b/src/demuxer.js
@@ -12,19 +12,19 @@ OggDemuxer.plugins.push({
   init: function() {
     this.vorbis = Vorbis._VorbisInit();
     this.buflen = 4096;
-    this.buf = Vorbis._malloc(this.buflen);
+    this.vorBuf = Vorbis._malloc(this.buflen);
     this.headers = 3;
     this.headerBuffers = [];
   },
 
   readHeaders: function(packet) {
     if (this.buflen < packet.length) {
-      this.buf = Vorbis._realloc(this.buf, packet.length);
+      this.vorBuf = Vorbis._realloc(this.vorBuf, packet.length);
       this.buflen = packet.length;
     }
     
-    Vorbis.HEAPU8.set(packet, this.buf);
-    if (Vorbis._VorbisHeaderDecode(this.vorbis, this.buf, packet.length) !== 0)
+    Vorbis.HEAPU8.set(packet, this.vorBuf);
+    if (Vorbis._VorbisHeaderDecode(this.vorbis, this.vorBuf, packet.length) !== 0)
       throw new Error("Invalid vorbis header");
       
     this.headerBuffers.push(packet);
@@ -49,7 +49,7 @@ OggDemuxer.plugins.push({
       this.emit('metadata', this.metadata);
       
       Vorbis._VorbisDestroy(this.vorbis);
-      Vorbis._free(this.buf);
+      Vorbis._free(this.vorBuf);
       this.vorbis = null;
       
       for (var i = 0; i < 3; i++)

--- a/src/demuxer.js
+++ b/src/demuxer.js
@@ -59,8 +59,11 @@ OggDemuxer.plugins.push({
     return this.headers === 0;
   },
   
-  readPacket: function(packet) {
-    this.emit('data', new AV.Buffer(packet));
+  readPacket: function(packet, streamEnd, granulePos) {
+    var data = new AV.Buffer(packet);
+    data._streamEnd = streamEnd;
+    data._granulePos = granulePos;
+    this.emit('data', data);
   }
 });
 


### PR DESCRIPTION
Ogg plugins extend the OggDemuxer object. The Vorbis plugin called its temporary buffer 'buf', which is the same as the Ogg demuxer's. This produced broken decodes. Fix is to rename the Vorbis buffer.

Also, if VorbisDecode calls the callback more than once, the first decoded buffer is lost. By emitting 'data' on each callback instead, this issue is avoided.
